### PR TITLE
Mistype in volume script

### DIFF
--- a/scripts/volume
+++ b/scripts/volume
@@ -13,7 +13,7 @@ STATE=`amixer sget Master | egrep -m 1 'Playback.*?\[o' | egrep -o '\[o.+\]'`
 if [[ $STATE == '[off]' ]]; then
         ICON=""
 else
-        VOLNUM=$(echo -e $VOLUME | egrep -o "[0-9]+")
+        VOLUME=$(echo -e $VOLUME | egrep -o "[0-9]+")
         if [ $VOLUME -lt "33" ]; then
                 ICON=""
         elif [ $VOLUME -lt "66" ]; then


### PR DESCRIPTION
Hi! I am using some of your public i3 scripts. And I found a mistake in the code that causes wrong volume level icon being rendered. Here is the fix.

P. S. Hmm... This looks like a good way of saying "thank you for your scripts." xD